### PR TITLE
CUDOS-219 Add additional env var for staking url

### DIFF
--- a/config/.env.example
+++ b/config/.env.example
@@ -21,6 +21,7 @@ API=
 GAS_PRICE=
 GAS=
 FEE=
+STAKING=<url_for_staking_button_in_keplr_wallet>
 
 #orchestrator variables
 ERC20_CONTRACT_ADDRESS=

--- a/config/config.js
+++ b/config/config.js
@@ -32,7 +32,8 @@ const envVariables = [
     'BRIDGE_CONTRACT_ADDRESS',
     'BRIDGE_FEE',
     'ETHEREUM_GAS_PRICE',
-    'ETHEREUM_GAS'
+    'ETHEREUM_GAS',
+    'STAKING'
 ];
 
 if (process.env.NODE_ENV === 'production') {
@@ -206,6 +207,7 @@ const Config = {
         GAS_PRICE: process.env.GAS_PRICE,
         FEE: process.env.FEE,
         GAS: process.env.GAS,
+        STAKING: process.env.STAKING
     },
     ORCHESTRATOR: {
         ERC20_CONTRACT_ADDRESS: process.env.ERC20_CONTRACT_ADDRESS,

--- a/src/frontend/resources/common/js/models/ledgers/KeplrLedger.ts
+++ b/src/frontend/resources/common/js/models/ledgers/KeplrLedger.ts
@@ -48,7 +48,7 @@ export default class KeplrLedger implements Ledger {
                     },
                     // (Optional) If you have a wallet webpage used to stake the coin then provide the url to the website in `walletUrlForStaking`.
                     // The 'stake' button in Keplr extension will link to the webpage.
-                    walletUrlForStaking: Config.CUDOS_NETWORK.RPC,
+                    walletUrlForStaking: Config.CUDOS_NETWORK.STAKING,
                     // The BIP44 path.
                     bip44: {
                         // You can only set the coin type of BIP44.


### PR DESCRIPTION
Additional env variable is added to the configuration. When deploying the UI it should point to the https://explorer.cudos.org/validators or corresponding url depending on environment. This is a workaround until we have a user friendly working staking UI part of the explorer.