### PR TITLE
CUDOS-1134 added link to cudos tx as well when transferring Ethereum -> Cudos

### DIFF
--- a/config/.env.example
+++ b/config/.env.example
@@ -23,7 +23,6 @@ API=
 GAS_PRICE=
 GAS=
 STAKING=<url_for_staking_button_in_keplr_wallet>
-PARAMS_ENDPOINT=""
 BLOCK_EXPLORER=(http://<explorer-web-address>/transactions)
 
 #orchestrator variables

--- a/config/config.js
+++ b/config/config.js
@@ -32,7 +32,6 @@ const envVariables = [
     'BRIDGE_CONTRACT_ADDRESS',
     'ETHEREUM_GAS',
     'STAKING',
-    'PARAMS_ENDPOINT',
     'BLOCK_EXPLORER',
     'NETWORK_TYPE'
 ];
@@ -210,7 +209,6 @@ const Config = {
         GAS_PRICE: process.env.GAS_PRICE,
         GAS: process.env.GAS,
         STAKING: process.env.STAKING,
-        PARAMS_ENDPOINT: process.env.PARAMS_ENDPOINT,
         BLOCK_EXPLORER: process.env.BLOCK_EXPLORER,
         MESSAGE_TYPE_URL: '/gravity.v1.MsgSendToEth',
     },

--- a/src/frontend/resources/common/js/components-popups/SummaryModal.tsx
+++ b/src/frontend/resources/common/js/components-popups/SummaryModal.tsx
@@ -16,6 +16,7 @@ const SummaryModal = ({
     displayAmount,
     onGetBalance,
     txHash,
+    destTxHash,
 }
     : { closeModal: Function,
         isOpen: boolean,
@@ -25,6 +26,7 @@ const SummaryModal = ({
         displayAmount: string,
         onGetBalance: Function,
         txHash: string,
+        destTxHash: string,
     }) => {
 
     const cudosLogoSmall = '../../../../resources/common/img/favicon/cudos-18x18.svg';
@@ -105,10 +107,18 @@ const SummaryModal = ({
                             </div>
                             <div className={'Row Spacing LinkWrapper'}>
                                 <div className={'LinkContent'}><a href= {`${selectedFromNetwork ? CUDOS_EXPLORER : ETHERSCAN_EXPLORER}/${txHash}`} rel='noreferrer' target='_blank'>
-                                    Bridge transaction link</a>
+                                    {selectedFromNetwork ? 'Cudos' : 'Ethereum'} Bridge transaction link</a>
                                 <div className={'LinkIcon'} style={ProjectUtils.makeBgImgStyle(linkIcon)} />
                                 </div>
                             </div>
+                            { selectedFromNetwork ? ''
+                                : <div className={'Row Spacing LinkWrapper'}>
+                                    <div className={'LinkContent'}><a href= {`${CUDOS_EXPLORER}/${txHash}`} rel='noreferrer' target='_blank'>
+                                        Cudos Bridge transaction link</a>
+                                    <div className={'LinkIcon'} style={ProjectUtils.makeBgImgStyle(linkIcon)} />
+                                    </div>
+                                </div>
+                            }
                             <div className={'Row DoubleSpacing'}>
                                 <div className={'TransactionMesasge'}>
                                     <div className={'AttentionIcon'} style={ProjectUtils.makeBgImgStyle(attentionIcon)}/>

--- a/src/frontend/resources/common/js/models/ledgers/Ledger.ts
+++ b/src/frontend/resources/common/js/models/ledgers/Ledger.ts
@@ -8,6 +8,7 @@ export default interface Ledger {
     account: string,
     walletError: string,
     txHash: string,
+    txNonce: Number,
     connect: () => Promise<void>,
     disconnect: () => Promise<void>,
     send: (amount: BigNumber, destination: string) => Promise<void>,

--- a/src/frontend/resources/common/js/models/ledgers/MetamaskLedger.ts
+++ b/src/frontend/resources/common/js/models/ledgers/MetamaskLedger.ts
@@ -17,6 +17,7 @@ export default class MetamaskLedger implements Ledger {
     @observable account: string;
     @observable walletError: string;
     @observable txHash: string;
+    @observable txNonce: Number;
     erc20Instance: any;
     gas: string;
 
@@ -93,9 +94,10 @@ export default class MetamaskLedger implements Ledger {
                             }
 
                             gravityContract.methods.sendToCosmos(Config.ORCHESTRATOR.ERC20_CONTRACT_ADDRESS, `0x${toHex(addressBytes32Array)}`, stringAmount).send({ from: account, gas: this.gas })
-                                .on('receipt', (confirmationNumber, receipt) => {
+                                .on('receipt', (confirmationNumber) => {
                                     resolve();
                                     this.txHash = confirmationNumber.transactionHash;
+                                    this.txNonce = confirmationNumber.events.SendToCosmosEvent.returnValues._eventNonce;
                                 })
                                 .on('error', (e) => {
                                     reject();


### PR DESCRIPTION
Added a functionality to get the tx hash of the cudos tx of a Ethereum -> Cudos transfer. The final transfer of funds from gravity module to the user is not an actual transaction, so we can't give a link to it. The next best thing we could do is get the orchestrator transaction for attestation. Since we are having one orchestrator that makes sure the transfer passes anyways, so it is an acceptable solution.

The idea of the function that gets the x hash on the cudos network is supposed to work as follows:
 - get the latest block on cudos network.
 - get the transfer nonce from the Ethereum transaction - it is unique for each transfer so it can be used as reference.
 - get all gravity transactions and filter to the ones that are after the selected block height
 - from them get the tx hashes and get the events
 - in the events search the nonce to be equal to the one gotten from the ethereum event.
 - the found tx is the one we need to show
 - if tx is not found, set the block height to the latest from the checked txs so far and repeat